### PR TITLE
Bugfix/scripts sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ yarn add react-twitch-embed
 * `onVideoPause` **\<Func\>**: Video pause event handler. (Default: `() => null`)
 * `onVideoReady` **\<Func\>**: Player ready event handler. Receives the player object. For more information on the available methods for the player object,
 check out the [Twitch Video & Clips Documentation](https://dev.twitch.tv/docs/embed/video-and-clips#interactive-frames-for-live-streams-and-vods) (Default: `() => null`)
+* `...props`: The rest of the props are supplied to the `div` node where the `iframe` is mounted.
 
 ### TwitchChat
 
 * `channel` **\<String\>**: Channel name to embed the chat. **Required**.
 * `id` **\<String\>**: ID of the `iframe` node where the chat embed is mounted. Specify this if you have multiple chat embeds on the same page. (Default: `twitch-chat-embed`)
-* `height` **\<Number\>**: Height of the chat embed in pixels. (Default: `500`)
-* `width` **\<Number\>**: Width of the chat embed in pixels. (Default: `350`)
-* `...props`: The `...props` object is supplied to chat embed `iframe` node.
+* `height` **\<Number | String\>**: Chat embed height in pixels. Allows strings formatted as percentage (i.e `'50%'`). (Default: `500`)
+* `width` **\<Number | String\>**: Chat embed width in pixels. Allows strings formatted as percentage (i.e `'50%'`). (Default: `350`)
+* `...props`: The rest of the props are supplied to chat embed `iframe` node.
 
 ### TwitchClip
 
@@ -55,10 +56,10 @@ check out the [Twitch Video & Clips Documentation](https://dev.twitch.tv/docs/em
 * `autoplay` **\<Boolean\>**: Whether the clip starts playing once the player is ready. (Default: `true`)
 * `muted` **\<Boolean\>**: Start the clip with the volume set to `0`. **Note:** By default, the clip player will be muted if the user hasn't
 clicked on it yet. (Default: `false`)
-* `height` **\<Number\>**: Height of the clip embed in pixels. (Default: `480`)
-* `width` **\<Number\>**: Width of the clip embed in pixels. (Default: `940`)
+* `height` **\<Number | String\>**: Clip embed height in pixels. Allows strings formatted as percentage (i.e `'50%'`). (Default: `480`)
+* `width` **\<Number | String\>**: Clip embed width in pixels. Allows strings formatted as percentage (i.e `'50%'`). (Default: `940`)
 * `allowFullscreen` **\<Boolean\>**: Allow the player to go on fullscreen mode. (Default: `true`)
-* `...props`: The `...props` object is supplied to the clip embed `iframe` node.
+* `...props`: The rest of the props are supplied to the clip embed `iframe` node.
 
 ### TwitchPlayer
 
@@ -66,8 +67,8 @@ clicked on it yet. (Default: `false`)
 * `channel` **\<String\>**: Name of the channel to stream using the player. (Default: `null`)
 * `collection` **\<String\>**: ID of the collection to play. (Default: `null`)
 * `video` **\<String\>**: ID of the video or VOD to play. (Default: `null`)
-* `height` **\<Number\>**: Height of the player embed in pixels. (Default: `940`)
-* `width` **\<Number\>**: Width of the player embed in pixels. (Default: `480`)
+* `height` **\<Number | String\>**: Player embed height in pixels. Allows strings formatted as percentage (i.e `'50%'`). (Default: `940`)
+* `width` **\<Number | String\>**: Player embed width in pixels. Allows strings formatted as percentage (i.e `'50%'`). (Default: `480`)
 * `playsInline` **\<Boolean\>**: Whether the embedded player plays inline for mobile iOS apps. (Default: `true`)
 * `autoplay` **\<Boolean\>**: Whether the player starts playing once it's ready. (Default: `true`)
 * `muted` **\<Boolean\>**: Whether the player starts muted. (Default: `false`)
@@ -82,6 +83,7 @@ clicked on it yet. (Default: `false`)
 * `onOnline` **\<Func\>**: Loaded channel goes online event handler. (Default: `() => null`)
 * `onReady` **\<Func\>**: Player ready event handler. Receives the player object. For more information on the available methods for the player object, 
 check out the [Twitch Video & Clips Documentation](https://dev.twitch.tv/docs/embed/video-and-clips#interactive-frames-for-live-streams-and-vods) (Default: `() => null`)
+* `...props`: The rest of the props are supplied to the `div` node where the `iframe` is mounted.
 
 > **Note**: If `channel`, `collection` and `video` are supplied, only `channel` is taken into account.
 > If `collection` and `video` are supplied, the player will play the videos in the collection starting from the video that was specified.
@@ -94,7 +96,9 @@ check out the [Twitch Video & Clips Documentation](https://dev.twitch.tv/docs/em
 > from outside, then `TwitchEmbed` should be fine. The key difference is that `TwitchPlayer` not only accepts VODs and collections,
 > it also has access to a more complete player object. Also, switching channels in `TwitchPlayer` is more fluid because it uses the
 > player API to switch the channel. This also happens on `TwitchEmbed` but only when `withChat` is set to `false`. If `withChat` is
-> set to `true` o `TwitchEmbed` and the `channel` prop is updated, it will recreate the embed.
+> set to `true` o `TwitchEmbed` and the `channel` prop is updated, it will recreate the embed. Another key difference is that `TwitchEmbed`
+> will download the Twitch Embed and Player scripts. When multiple Embeds are mounted in the same page, the Player script will be downloaded
+> for each `TwitchEmbed` on the page. `TwitchPlayer` will only download it once.
 
 * **Why is there `TwitchClip` and `TwitchPlayer`?**
 > Twitch handles clips and VODs differently, this is also true for their embeds. `TwitchClip` will only work for clips whereas

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -77,20 +77,25 @@ class App extends Component {
 
     return (
       <div>
-        <button onClick={this.handleEnable}>Enable/Disable</button>
-        <button onClick={this.handleChangeChannel}>Change channel</button>
-        <button onClick={this.handleCollectionChange}>Change collection</button>
-        <button onClick={this.handleVideoChange}>Change video</button>
-        <button onClick={this.handleAllChange}>Change all</button>
-        <button onClick={this.handleChangeChannelWidth}>Change channel and width</button>
-        <button onClick={this.handleChangeChat}>Toggle chat</button>
+        {/*<button onClick={this.handleEnable}>Enable/Disable</button>*/}
+        {/*<button onClick={this.handleChangeChannel}>Change channel</button>*/}
+        {/*<button onClick={this.handleCollectionChange}>Change collection</button>*/}
+        {/*<button onClick={this.handleVideoChange}>Change video</button>*/}
+        {/*<button onClick={this.handleAllChange}>Change all</button>*/}
+        {/*<button onClick={this.handleChangeChannelWidth}>Change channel and width</button>*/}
+        {/*<button onClick={this.handleChangeChat}>Toggle chat</button>*/}
+        {/*{*/}
+        {/*  enabled &&*/}
+        {/*  <TwitchEmbed channel={channel} autoplay={false} muted fontSize="large" theme="dark" withChat={chat} />*/}
+        {/*}*/}
+        {/*<TwitchChat channel={channel} style={{ padding: 50, background: 'black' }} />*/}
+        {/*<TwitchClip clip="WealthyBumblingKimchiItsBoshyTime" />*/}
+        {/*<TwitchPlayer width={width} collection={collection} video={video} />*/}
         {
-          enabled &&
-          <TwitchEmbed channel={channel} autoplay={false} muted fontSize="large" theme="dark" withChat={chat} />
+          channels.map((channel) =>
+            <TwitchPlayer key={channel} id={channel} channel={channel} />
+          )
         }
-        <TwitchChat channel={channel} style={{ padding: 50, background: 'black' }} />
-        <TwitchClip clip="WealthyBumblingKimchiItsBoshyTime" />
-        <TwitchPlayer width={width} collection={collection} video={video} />
       </div>
     );
   }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -96,7 +96,7 @@ class App extends Component {
         {/*    <TwitchPlayer key={channel} id={channel} channel={channel} />*/}
         {/*  )*/}
         {/*}*/}
-        <TwitchChat style={{ width: '100vw', height: '100vh'}} channel="method" />
+        <TwitchClip width="100%" height="99vh" clip="WealthyBumblingKimchiItsBoshyTime" />
       </div>
     );
   }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -91,11 +91,12 @@ class App extends Component {
         {/*<TwitchChat channel={channel} style={{ padding: 50, background: 'black' }} />*/}
         {/*<TwitchClip clip="WealthyBumblingKimchiItsBoshyTime" />*/}
         {/*<TwitchPlayer width={width} collection={collection} video={video} />*/}
-        {
-          channels.map((channel) =>
-            <TwitchPlayer key={channel} id={channel} channel={channel} />
-          )
-        }
+        {/*{*/}
+        {/*  channels.map((channel) =>*/}
+        {/*    <TwitchPlayer key={channel} id={channel} channel={channel} />*/}
+        {/*  )*/}
+        {/*}*/}
+        <TwitchChat style={{ width: '100vw', height: '100vh'}} channel="method" />
       </div>
     );
   }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -91,12 +91,11 @@ class App extends Component {
         {/*<TwitchChat channel={channel} style={{ padding: 50, background: 'black' }} />*/}
         {/*<TwitchClip clip="WealthyBumblingKimchiItsBoshyTime" />*/}
         {/*<TwitchPlayer width={width} collection={collection} video={video} />*/}
-        {/*{*/}
-        {/*  channels.map((channel) =>*/}
-        {/*    <TwitchPlayer key={channel} id={channel} channel={channel} />*/}
-        {/*  )*/}
-        {/*}*/}
-        <TwitchClip width="100%" height="99vh" clip="WealthyBumblingKimchiItsBoshyTime" />
+        {
+          channels.map((channel) =>
+            <TwitchEmbed className="twitch-embed" width="50%" key={channel} id={channel} channel={channel} />
+          )
+        }
       </div>
     );
   }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,99 +1,15 @@
 import React, { Component } from 'react';
-import { TwitchEmbed, TwitchChat, TwitchClip, TwitchPlayer } from 'react-twitch-embed';
+import { TwitchPlayer } from 'react-twitch-embed';
 
 const channels = ['loltyler1', 'moonstar_x', 'method', 'Rainbow6'];
-const collections = ['YfGvvNZI9RWlEQ', '7n-aaF6m9RVAVQ'];
-const videos = ['260075663'];
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      enabled: true,
-      channel: channels[2],
-      video: videos[0],
-      collection: collections[1],
-      width: 900,
-      chat: false
-    };
-
-    this.handleEnable = this.handleEnable.bind(this);
-    this.handleChangeChannel = this.handleChangeChannel.bind(this);
-    this.handleCollectionChange = this.handleCollectionChange.bind(this);
-    this.handleVideoChange = this.handleVideoChange.bind(this);
-    this.handleAllChange = this.handleAllChange.bind(this);
-    this.handleChangeChannelWidth = this.handleChangeChannelWidth.bind(this);
-    this.handleChangeChat = this.handleChangeChat.bind(this);
-  }
-
-  handleEnable() {
-    this.setState({
-      enabled: !this.state.enabled
-    });
-  }
-
-  handleChangeChannel() {
-    this.setState({
-      channel: channels[Math.floor(Math.random() * channels.length)]
-    });
-  }
-
-  handleCollectionChange() {
-    this.setState({
-      collection: collections[Math.floor(Math.random() * collections.length)]
-    });
-  }
-
-  handleVideoChange() {
-    this.setState({
-      video: videos[Math.floor(Math.random() * videos.length)]
-    });
-  }
-
-  handleAllChange() {
-    this.setState({
-      channel: channels[Math.floor(Math.random() * channels.length)],
-      collection: collections[Math.floor(Math.random() * collections.length)],
-      video: videos[Math.floor(Math.random() * videos.length)]
-    });
-  }
-
-  handleChangeChannelWidth() {
-    this.setState({
-      channel: channels[Math.floor(Math.random() * channels.length)],
-      width: this.state.width === 900 ? 600 : 900
-    });
-  }
-
-  handleChangeChat() {
-    this.setState({
-      chat: !this.state.chat
-    });
-  }
-
   render() {
-    const { channel, enabled, video, collection, width, chat } = this.state;
-
     return (
       <div>
-        {/*<button onClick={this.handleEnable}>Enable/Disable</button>*/}
-        {/*<button onClick={this.handleChangeChannel}>Change channel</button>*/}
-        {/*<button onClick={this.handleCollectionChange}>Change collection</button>*/}
-        {/*<button onClick={this.handleVideoChange}>Change video</button>*/}
-        {/*<button onClick={this.handleAllChange}>Change all</button>*/}
-        {/*<button onClick={this.handleChangeChannelWidth}>Change channel and width</button>*/}
-        {/*<button onClick={this.handleChangeChat}>Toggle chat</button>*/}
-        {/*{*/}
-        {/*  enabled &&*/}
-        {/*  <TwitchEmbed channel={channel} autoplay={false} muted fontSize="large" theme="dark" withChat={chat} />*/}
-        {/*}*/}
-        {/*<TwitchChat channel={channel} style={{ padding: 50, background: 'black' }} />*/}
-        {/*<TwitchClip clip="WealthyBumblingKimchiItsBoshyTime" />*/}
-        {/*<TwitchPlayer width={width} collection={collection} video={video} />*/}
         {
           channels.map((channel) =>
-            <TwitchEmbed className="twitch-embed" width="50%" key={channel} id={channel} channel={channel} />
+            <TwitchPlayer className="twitch-embed" width="50%" key={channel} id={channel} channel={channel} />
           )
         }
       </div>

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -3,3 +3,7 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
+
+.twitch-embed {
+  display: inline-block;
+}

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,7 +1,6 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
+import React from 'react';
+import ReactDOM from 'react-dom';
+import './index.css';
+import App from './App';
 
-import './index.css'
-import App from './App'
-
-ReactDOM.render(<App />, document.getElementById('root'))
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/components/TwitchChat.js
+++ b/src/components/TwitchChat.js
@@ -37,8 +37,8 @@ class TwitchChat extends Component {
 TwitchChat.propTypes = {
   channel: PropTypes.string.isRequired,
   id: PropTypes.string,
-  height: PropTypes.number,
-  width: PropTypes.number
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 TwitchChat.defaultProps = {

--- a/src/components/TwitchClip.js
+++ b/src/components/TwitchClip.js
@@ -40,8 +40,8 @@ TwitchClip.propTypes = {
   id: PropTypes.string,
   autoplay: PropTypes.bool,
   muted: PropTypes.bool,
-  height: PropTypes.number,
-  width: PropTypes.number,
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   allowFullscreen: PropTypes.bool
 };
 

--- a/src/components/TwitchEmbed.js
+++ b/src/components/TwitchEmbed.js
@@ -7,6 +7,39 @@ scriptElement.setAttribute('type', 'text/javascript');
 scriptElement.setAttribute('src', TWITCH_EMBED_URL);
 let scriptAdded = false;
 
+const propTypes = {
+  id: PropTypes.string,
+  allowFullscreen: PropTypes.bool,
+  channel: PropTypes.string.isRequired,
+  fontSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  withChat: PropTypes.bool,
+  theme: PropTypes.oneOf(['light', 'dark']),
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onAuthenticate: PropTypes.func,
+  onVideoPlay: PropTypes.func,
+  onVideoPause: PropTypes.func,
+  onVideoReady: PropTypes.func,
+  autoplay: PropTypes.bool,
+  muted: PropTypes.bool
+};
+
+const defaultProps = {
+  id: 'twitch-embed',
+  allowFullscreen: true,
+  fontSize: 'small',
+  height: MEDIA_DEFAULT_HEIGHT,
+  withChat: true,
+  theme: 'light',
+  width: MEDIA_DEFAULT_WIDTH,
+  onAuthenticate: () => null,
+  onVideoPlay: () => null,
+  onVideoPause: () => null,
+  onVideoReady: () => null,
+  autoplay: true,
+  muted: false
+};
+
 class TwitchEmbed extends Component {
   constructor(props) {
     super(props);
@@ -68,10 +101,10 @@ class TwitchEmbed extends Component {
       allowfullscreen: this.props.allowFullscreen,
       channel: this.props.channel,
       'font-size': this.props.fontSize,
-      height: this.props.height,
+      height: '100%',
       layout: this.props.withChat ? 'video-with-chat' : 'video',
       theme: this.props.theme,
-      width: this.props.width
+      width: '100%'
     });
 
     this._addEventListeners();
@@ -104,45 +137,22 @@ class TwitchEmbed extends Component {
   }
 
   render() {
-    const { id, width, height } = this.props;
+    const unknownProps = Object.keys(this.props).reduce((unknown, prop) => {
+      if (propTypes.hasOwnProperty(prop)) {
+        return unknown;
+      }
+
+      unknown[prop] = this.props[prop];
+      return unknown;
+    }, {});
 
     return (
-      <div style={{ width, height }} id={id} />
+      <div style={{ width: this.props.width, height: this.props.height }} id={this.props.id} {...unknownProps} />
     );
   }
 }
 
-TwitchEmbed.propTypes = {
-  id: PropTypes.string,
-  allowFullscreen: PropTypes.bool,
-  channel: PropTypes.string.isRequired,
-  fontSize: PropTypes.oneOf(['small', 'medium', 'large']),
-  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  withChat: PropTypes.bool,
-  theme: PropTypes.oneOf(['light', 'dark']),
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onAuthenticate: PropTypes.func,
-  onVideoPlay: PropTypes.func,
-  onVideoPause: PropTypes.func,
-  onVideoReady: PropTypes.func,
-  autoplay: PropTypes.bool,
-  muted: PropTypes.bool
-};
-
-TwitchEmbed.defaultProps = {
-  id: 'twitch-embed',
-  allowFullscreen: true,
-  fontSize: 'small',
-  height: MEDIA_DEFAULT_HEIGHT,
-  withChat: true,
-  theme: 'light',
-  width: MEDIA_DEFAULT_WIDTH,
-  onAuthenticate: () => null,
-  onVideoPlay: () => null,
-  onVideoPause: () => null,
-  onVideoReady: () => null,
-  autoplay: true,
-  muted: false
-};
+TwitchEmbed.propTypes = propTypes;
+TwitchEmbed.defaultProps = defaultProps;
 
 export default TwitchEmbed;

--- a/src/components/TwitchEmbed.js
+++ b/src/components/TwitchEmbed.js
@@ -2,7 +2,21 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TWITCH_EMBED_URL, MEDIA_DEFAULT_WIDTH, MEDIA_DEFAULT_HEIGHT } from '../constants';
 
+const scriptElement = document.createElement('script');
+scriptElement.setAttribute('type', 'text/javascript');
+scriptElement.setAttribute('src', TWITCH_EMBED_URL);
+let scriptAdded = false;
+
 class TwitchEmbed extends Component {
+  constructor(props) {
+    super(props);
+
+    if (!scriptAdded) {
+      document.body.appendChild(scriptElement);
+      scriptAdded = true;
+    }
+  }
+
   componentDidMount() {
     this._validateProps();
 
@@ -10,14 +24,9 @@ class TwitchEmbed extends Component {
       return this._createEmbed();
     }
 
-    const scriptElement = document.createElement('script');
-    scriptElement.setAttribute('src', TWITCH_EMBED_URL);
-
     scriptElement.addEventListener('load', () => {
       this._createEmbed();
     });
-
-    document.body.appendChild(scriptElement);
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {

--- a/src/components/TwitchPlayer.js
+++ b/src/components/TwitchPlayer.js
@@ -9,6 +9,50 @@ scriptElement.setAttribute('type', 'text/javascript');
 scriptElement.setAttribute('src', TWITCH_PLAYER_URL);
 let scriptAdded = false;
 
+const propTypes = {
+  id: PropTypes.string,
+  channel: PropTypes.string,
+  collection: PropTypes.string,
+  video: PropTypes.string,
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  playsInline: PropTypes.bool,
+  autoplay: PropTypes.bool,
+  muted: PropTypes.bool,
+  allowFullscreen: PropTypes.bool,
+  time: PropTypes.string,
+  onEnded: PropTypes.func,
+  onPause: PropTypes.func,
+  onPlay: PropTypes.func,
+  onPlaybackBlocked: PropTypes.func,
+  onPlaying: PropTypes.func,
+  onOffline: PropTypes.func,
+  onOnline: PropTypes.func,
+  onReady: PropTypes.func
+};
+
+const defaultProps = {
+  id: 'twitch-player-embed',
+  channel: null,
+  collection: null,
+  video: null,
+  height: MEDIA_DEFAULT_HEIGHT,
+  width: MEDIA_DEFAULT_WIDTH,
+  playsInline: true,
+  autoplay: true,
+  muted: false,
+  allowFullscreen: true,
+  time: '0h0m0s',
+  onEnded: () => null,
+  onPause: () => null,
+  onPlay: () => null,
+  onPlaybackBlocked: () => null,
+  onPlaying: () => null,
+  onOffline: () => null,
+  onOnline: () => null,
+  onReady: () => null
+};
+
 class TwitchPlayer extends Component {
   constructor(props) {
     super(props);
@@ -66,8 +110,8 @@ class TwitchPlayer extends Component {
 
   _createPlayer() {
     const options = {
-      height: this.props.height,
-      width: this.props.width,
+      height: '100%',
+      width: '100%',
       playsinline: this.props.playsInline,
       allowfullscreen: this.props.allowFullscreen,
       autoplay: this.props.autoplay,
@@ -113,56 +157,22 @@ class TwitchPlayer extends Component {
   }
 
   render() {
-    const { id, width, height } = this.props;
+    const unknownProps = Object.keys(this.props).reduce((unknown, prop) => {
+      if (propTypes.hasOwnProperty(prop)) {
+        return unknown;
+      }
+
+      unknown[prop] = this.props[prop];
+      return unknown;
+    }, {});
 
     return (
-      <div id={id} style={{ width, height }} />
+      <div id={this.props.id} style={{ width: this.props.width, height: this.props.height }} {...unknownProps} />
     );
   }
 }
 
-TwitchPlayer.propTypes = {
-  id: PropTypes.string,
-  channel: PropTypes.string,
-  collection: PropTypes.string,
-  video: PropTypes.string,
-  height: PropTypes.number,
-  width: PropTypes.number,
-  playsInline: PropTypes.bool,
-  autoplay: PropTypes.bool,
-  muted: PropTypes.bool,
-  allowFullscreen: PropTypes.bool,
-  time: PropTypes.string,
-  onEnded: PropTypes.func,
-  onPause: PropTypes.func,
-  onPlay: PropTypes.func,
-  onPlaybackBlocked: PropTypes.func,
-  onPlaying: PropTypes.func,
-  onOffline: PropTypes.func,
-  onOnline: PropTypes.func,
-  onReady: PropTypes.func
-};
-
-TwitchPlayer.defaultProps = {
-  id: 'twitch-player-embed',
-  channel: null,
-  collection: null,
-  video: null,
-  height: MEDIA_DEFAULT_HEIGHT,
-  width: MEDIA_DEFAULT_WIDTH,
-  playsInline: true,
-  autoplay: true,
-  muted: false,
-  allowFullscreen: true,
-  time: '0h0m0s',
-  onEnded: () => null,
-  onPause: () => null,
-  onPlay: () => null,
-  onPlaybackBlocked: () => null,
-  onPlaying: () => null,
-  onOffline: () => null,
-  onOnline: () => null,
-  onReady: () => null
-};
+TwitchPlayer.propTypes = propTypes;
+TwitchPlayer.defaultProps = defaultProps;
 
 export default TwitchPlayer;

--- a/src/components/TwitchPlayer.js
+++ b/src/components/TwitchPlayer.js
@@ -4,7 +4,21 @@ import { TWITCH_PLAYER_URL, MEDIA_DEFAULT_WIDTH, MEDIA_DEFAULT_HEIGHT } from '..
 
 const mediaProps = ['channel', 'collection', 'video'];
 
+const scriptElement = document.createElement('script');
+scriptElement.setAttribute('type', 'text/javascript');
+scriptElement.setAttribute('src', TWITCH_PLAYER_URL);
+let scriptAdded = false;
+
 class TwitchPlayer extends Component {
+  constructor(props) {
+    super(props);
+
+    if (!scriptAdded) {
+      document.body.appendChild(scriptElement);
+      scriptAdded = true;
+    }
+  }
+
   componentDidMount() {
     this._validateProps();
 
@@ -12,14 +26,9 @@ class TwitchPlayer extends Component {
       return this._createPlayer();
     }
 
-    const scriptElement = document.createElement('script');
-    scriptElement.setAttribute('src', TWITCH_PLAYER_URL);
-
     scriptElement.addEventListener('load', () => {
       this._createPlayer();
     });
-
-    document.body.appendChild(scriptElement);
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {


### PR DESCRIPTION
Fixed a bug where `TwitchPlayer` and `TwitchEmbed` would download the required scripts for every component rendered.

Fixed a bug where the sizing of the player would not correspond to the size of the parent `div`.

Added the option to specify other props in the `TwitchPlayer` and `TwitchEmbed` `divs`.